### PR TITLE
Fixes Dead Doc Links from README

### DIFF
--- a/.docs/user-guide/servers/csi.md
+++ b/.docs/user-guide/servers/csi.md
@@ -26,7 +26,7 @@ idempotent as well. Not only that, but REX-Ray supports native CSI plug-ins!
 | Dell EMC | [Isilon](../storage-providers/dellemc.md#dell-emc-isilon) | ✓ | ✓ | ✓ |
 | | [ScaleIO](../storage-providers/dellemc.md#dell-emc-scaleio) | ✓ | ✓ | ✓ |
 | DigitalOcean | [Block Storage](../storage-providers/digitalocean.md#do-block-storage) | ✓ | ✓ | ✓ |
-| FittedCloud | [EBS Optimizer](../storage-providers/fittedcloud.md/#ebs-optimizer) | ✓ | ✓ | |
+| FittedCloud | [EBS Optimizer](../storage-providers/fittedcloud.md#ebs-optimizer) | ✓ | ✓ | |
 | Google | [GCE Persistent Disk](../storage-providers/google.md#gce-persistent-disk) | ✓ | ✓ | ✓ |
 | Microsoft | [Azure Unmanaged Disk](../storage-providers/microsoft.md#azure-ud) | ✓ | ✓ | ✓ |
 | OpenStack | [Cinder](../storage-providers/openstack.md#cinder) | ✓ | ✓ | ✓ |

--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ The following storage providers and platforms are supported by REX-Ray.
 
 | Provider              | Storage Platform  | <center>[Docker](https://docs.docker.com/engine/extend/plugins_volume/)</center> | <center>[CSI](https://github.com/container-storage-interface/spec)</center> | <center>Containerized</center> |
 |-----------------------|----------------------|:---:|:---:|:---:|
-| Amazon EC2 | [EBS](./user-guide/storage-providers.md#aws-ebs) | ✓ | ✓ | ✓  |
-| | [EFS](./user-guide/storage-providers.md#aws-efs) | ✓ | ✓ | ✓ |
-| | [S3FS](./user-guide/storage-providers.md#aws-s3fs) | ✓ | ✓ | ✓ |
-| Ceph | [RBD](./user-guide/storage-providers.md#ceph-rbd) | ✓ | ✓ | ✓ |
+| Amazon EC2 | [EBS](.docs/user-guide/storage-providers/aws.md#aws-ebs) | ✓ | ✓ | ✓  |
+| | [EFS](.docs/user-guide/storage-providers/aws.md#aws-efs) | ✓ | ✓ | ✓ |
+| | [S3FS](.docs/user-guide/storage-providers/aws.md#aws-s3fs) | ✓ | ✓ | ✓ |
+| Ceph | [RBD](.docs/user-guide/storage-providers/ceph.md#ceph-rbd) | ✓ | ✓ | ✓ |
 | Local | [CSI-BlockDevices](https://github.com/codedellemc/csi-blockdevices) | | ✓ | ✓ |
 | | [CSI-NFS](https://github.com/codedellemc/csi-nfs) | ✓ | ✓ | ✓ |
 | | [CSI-VFS](https://github.com/codedellemc/csi-vfs) | | ✓ | ✓ |
-| Dell EMC | [Isilon](./user-guide/storage-providers.md#dell-emc-isilon) | ✓ | ✓ | ✓ |
-| | [ScaleIO](./user-guide/storage-providers.md#dell-emc-scaleio) | ✓ | ✓ | ✓ |
-| DigitalOcean | [Block Storage](./user-guide/storage-providers.md#do-block-storage) | ✓ | ✓ | ✓ |
-| FittedCloud | [EBS Optimizer](./user-guide/storage-providers.md/#ebs-optimizer) | ✓ | ✓ | |
-| Google | [GCE Persistent Disk](./user-guide/storage-providers.md#gce-persistent-disk) | ✓ | ✓ | ✓ |
-| Microsoft | [Azure Unmanaged Disk](./user-guide/storage-providers.md#azure-ud) | ✓ | ✓ | ✓ |
-| OpenStack | [Cinder](./user-guide/storage-providers.md#cinder) | ✓ | ✓ | ✓ |
-| VirtualBox | [Virtual Media](./user-guide/storage-providers.md#virtualbox) | ✓ | ✓ | |
+| Dell EMC | [Isilon](.docs/user-guide/storage-providers/dellemc.md#dell-emc-isilon) | ✓ | ✓ | ✓ |
+| | [ScaleIO](.docs/user-guide/storage-providers/dellemc.md#dell-emc-scaleio) | ✓ | ✓ | ✓ |
+| DigitalOcean | [Block Storage](.docs/user-guide/storage-providers/digitalocean.md#do-block-storage) | ✓ | ✓ | ✓ |
+| FittedCloud | [EBS Optimizer](.docs/user-guide/storage-providers/fittedcloud.md#ebs-optimizer) | ✓ | ✓ | |
+| Google | [GCE Persistent Disk](.docs/user-guide/storage-providers/google.md#gce-persistent-disk) | ✓ | ✓ | ✓ |
+| Microsoft | [Azure Unmanaged Disk](.docs/user-guide/storage-providers/microsoft.md#azure-ud) | ✓ | ✓ | ✓ |
+| OpenStack | [Cinder](.docs/user-guide/storage-providers/openstack.md#cinder) | ✓ | ✓ | ✓ |
+| VirtualBox | [Virtual Media](.docs/user-guide/storage-providers/virtualbox.md#virtualbox) | ✓ | ✓ | |
 
 ### Operating System Support
 The following operating systems are supported by REX-Ray:


### PR DESCRIPTION
This patch fixes some dead documentation links from the project's root `README.md` file.

Fixes #1079