### PR TITLE
ceph: Fix how ceph CLI args are parsed

### DIFF
--- a/libstorage/drivers/storage/rbd/storage/rbd_storage.go
+++ b/libstorage/drivers/storage/rbd/storage/rbd_storage.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"regexp"
-	"strings"
 
 	gofig "github.com/akutz/gofig/types"
 	"github.com/akutz/goof"
@@ -50,7 +49,7 @@ func (d *driver) Init(ctx types.Context, config gofig.Config) error {
 	d.config = config
 	d.defaultPool = d.config.GetString(rbd.ConfigDefaultPool)
 	cephArgs := d.config.GetString(rbd.ConfigCephArgs)
-	if cephArgs == "" || !strContainsClient(cephArgs) {
+	if cephArgs == "" || !utils.StrContainsClient(cephArgs) {
 		d.multiPool = true
 	}
 	ctx.Info("storage driver initialized")
@@ -492,16 +491,4 @@ func (d *driver) parseVolumeID(name *string) (*string, *string, error) {
 
 	pool := d.defaultPool
 	return &pool, name, nil
-}
-
-// Search str arg for flags that can set a Ceph client id/name
-func strContainsClient(arg string) bool {
-	fields := strings.Split(arg, "")
-	for _, s := range fields {
-		switch s {
-		case "--id", "--user", "-n", "--name":
-			return true
-		}
-	}
-	return false
 }

--- a/libstorage/drivers/storage/rbd/utils/utils.go
+++ b/libstorage/drivers/storage/rbd/utils/utils.go
@@ -424,3 +424,15 @@ func RunCommand(
 	}
 	return nil, exitStatus, goof.Newe(err)
 }
+
+//StrContainsClient search str arg for flags that can set a Ceph client id/name
+func StrContainsClient(arg string) bool {
+	fields := strings.Split(arg, " ")
+	for _, s := range fields {
+		switch s {
+		case "--id", "--user", "-n", "--name":
+			return true
+		}
+	}
+	return false
+}

--- a/libstorage/drivers/storage/rbd/utils/utils_test.go
+++ b/libstorage/drivers/storage/rbd/utils/utils_test.go
@@ -75,3 +75,47 @@ func TestParseMonitorAddresses(t *testing.T) {
 		assert.True(t, test.ip.Equal(ip[0]))
 	}
 }
+
+func TestArgsClient(t *testing.T) {
+	tests := []struct {
+		args    string
+		present bool
+	}{
+		{
+			args:    "--id myuser",
+			present: true,
+		},
+		{
+			args:    "--user myuser",
+			present: true,
+		},
+		{
+			args:    "-n client.myuser",
+			present: true,
+		},
+		{
+			args:    "--name client.myuser",
+			present: true,
+		},
+		{
+			args:    "--cluster cluster2",
+			present: false,
+		},
+		{
+			args:    "--cluster cluster2 --id ceph",
+			present: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(st *testing.T) {
+			st.Parallel()
+			b := StrContainsClient(tt.args)
+			if b != tt.present {
+				t.Errorf("detection of client in cephArgs: %s incorrect, got: %v want: %v",
+					tt.args, b, tt.present)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `strContainsClient` function is splitting characters instead of words and not correctly determining if a user has been defined.

I mistakenly closed the original merge request #1083 while rebasing.  