### PR TITLE
Packaging install/uninstall fixes

### DIFF
--- a/cli/installer.go
+++ b/cli/installer.go
@@ -13,9 +13,10 @@ import (
 	"text/template"
 
 	"github.com/akutz/gotil"
+	log "github.com/sirupsen/logrus"
+
 	apitypes "github.com/thecodeteam/rexray/libstorage/api/types"
 	"github.com/thecodeteam/rexray/util"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -324,7 +325,8 @@ func createUnitFile(ctx apitypes.Context) error {
 		return fmt.Errorf("exec unit file template failed: %v", err)
 	}
 	text := buf.String()
-	f, err := os.OpenFile(util.UnitFilePath, os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(util.UnitFilePath,
+		os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf(
 			"create unit file failed: %s: %v", util.UnitFilePath, err)
@@ -374,7 +376,8 @@ func createInitFile() error {
 	// wrapped in a function to defer the close to ensure file is written to
 	// disk before subsequent chmod below
 	if err := func() error {
-		f, err := os.OpenFile(util.InitFilePath, os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(util.InitFilePath,
+			os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {
 			return fmt.Errorf(
 				"create init file failed: %s: %v", util.InitFilePath, err)

--- a/cli/service.go
+++ b/cli/service.go
@@ -279,7 +279,7 @@ func serviceStatus(ctx apitypes.Context) {
 
 func stopViaSystemD() {
 	execSystemDCmd("stop")
-	statusViaSystemD()
+	//statusViaSystemD()
 }
 
 func statusViaSystemD() {


### PR DESCRIPTION
There are two commits here. 

First addresses an issue that happens during package upgrade, where the systemd unit file became corrupted after [241b8eea](https://github.com/thecodeteam/rexray/commit/241b8eeaf9a0e81a81a418758c6f0454546f8600#diff-bf77ad614d635a5adb40baea31837892R327) was merged. This changed the unit file template, seemingly for the first time, and made the file a different length. This led to a corrupted unit definition because the new unit file was shorter than the old one.  This started happening with the release of 0.10.2. From the patch commit message:

>When `rexray install` is called, it writes out a new unit/init script
depending on the system. This patch makes sure the file is erased
(truncated) first, so the entire file is written out anew. The previous
logic merely overwrote the old file without erasing it first, which
could lead to incomplete/invalid files.

This is a side effect of having the `rexray` binary write out the unit file rather than being a managed file/property of the package itself. This will be addressed in the future.

The second commit addresses a problem that more people are hitting, which is the inability to install, remove, or upgrade REX-Ray entirely. The change that occurred was in 0.10.2, and happened [here](https://github.com/thecodeteam/rexray/commit/64b58139bc783fcca8f580fc6db10f8cb8b98657#diff-6fd23186b95e45c87244339a52981282R306)

From the patch commit message:

>A previous commit made it such that any error code returned from a
systemctl command led to an os.exit being called. This leads to errors
when doing package uninstalls in a variety of scenarios, because
the packages call `systemctl status -l rexray`, and if this is in an
error state for *any* reason (of which there can be several) the package
operation fails completely.

>The fix here is temporary, and makes it such that a call to `status` is
not made after a service stop command is performed. The only visible to
effect to the user is less output if they happen to run
`rexray service stop|restart`, which is a command we will phase out
soon enough. `rexray service status` still behaves the same.

If `systemctl status rexray` returned an error for any reason, you could no longer make any changes to the package -- no upgrades, no uninstalls. This is easy to hit, because simply installing REX-Ray for the first time will trigger this:

```sh
# curl -sSL https://dl.bintray.com/emccode/rexray/install | sh

rexray has been installed to /usr/bin/rexray

REX-Ray
-------
Binary: /usr/bin/rexray
Flavor: client+agent+controller
SemVer: 0.11.0
OsArch: Linux-x86_64
Commit: 508023f4b0e4974f1844c26b39af7c4219f4c7a9
Formed: Mon, 16 Oct 2017 07:07:06 UTC

[root@localhost ~]# systemctl status rexray
● rexray.service - rexray
   Loaded: loaded (/etc/systemd/system/rexray.service; enabled; vendor preset: disabled)
   Active: inactive (dead)
[root@localhost ~]# echo $?
3
```

This is again a side effect of having `rexray` manage the unit file and service enablement rather than leaving it to the package and the sysadmin. It is on the roadmap to address this comprehensively in 0.13.

Users that have hit this will have to do a bit of manual cleanup to get their package working again, as the RPM/DEB files and systemd are not talking to each other nicely. The RPM/DEB package has to be forcibly removed before a new install can be done (with `rpm -e --noscripts`), and a DEB user can follow what another user did in #1096.

Fixes #1088 
Fixes #1096