### PR TITLE
Fix disablement of path caching

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -33,7 +33,6 @@ func Start(
 
 	// Enable path caching for the modules.
 	config = config.Scope(configRexrayAgent)
-	config.Set(apitypes.ConfigIgVolOpsPathCacheEnabled, true)
 
 	// Activate libStorage if necessary.
 	var (

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -289,6 +289,10 @@ func (c *CLI) updateLogLevel() {
 }
 
 func (c *CLI) preRunActivateLibStorage(cmd *cobra.Command, args []string) {
+	// Disable patch caching for the CLI
+	c.config = c.config.Scope(configRexrayCLI)
+	c.config.Set(apitypes.ConfigIgVolOpsPathCacheEnabled, false)
+
 	c.activateLibStorage = true
 	c.preRun(cmd, args)
 }
@@ -299,10 +303,6 @@ const (
 
 func (c *CLI) preRun(cmd *cobra.Command, args []string) {
 	c.updateLogLevel()
-
-	// Disable patch caching for the CLI
-	c.config = c.config.Scope(configRexrayCLI)
-	c.config.Set(apitypes.ConfigIgVolOpsPathCacheEnabled, false)
 
 	if v := c.rrHost(); v != "" {
 		c.config.Set(apitypes.ConfigHost, v)


### PR DESCRIPTION
Even though there was a config option to disable path caching, it was
essentially being ignored. There were competing scenarios that forced
path caching to always be enabled no matter.

This patch achieves the desired scenario of:
- If running a one-off CLI command (e.g. "rexray volume ...") path caching
is disabled entirely.
- If REX-Ray is run as a service, path caching is controlled via config
  options, and still currently defaults to "enabled".