### PR TITLE
Use correct uname machine hardware name for s390x

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -166,5 +166,5 @@ var goarchToUname = map[string]string{
 	"mipsle":   "MIPS32LE",
 	"ppc64":    "PPC64",
 	"ppc64le":  "PPC64LE",
-	"s390x":    "S390X",
+	"s390x":    "s390x",
 }

--- a/core/semver/semver.go
+++ b/core/semver/semver.go
@@ -288,7 +288,7 @@ var goarchToUname = map[string]string{
 	"mipsle":   "MIPS32LE",
 	"ppc64":    "PPC64",
 	"ppc64le":  "PPC64LE",
-	"s390x":    "S390X",
+	"s390x":    "s390x",
 }
 
 func fileExists(filePath string) bool {


### PR DESCRIPTION
Currently the string "S390X" is used which leads to the following build error:

```
# make rpm
setarch: S390X: Unrecognized architecture
Makefile:123: recipe for target 'rexray-0.11.0+13-1.S390X.rpm' failed
```

The correct uname machine name is "s390x":

```
# uname -m
s390x
```

So fix this an use the correct name.