### PR TITLE
Fix Azure unmount disk

### DIFF
--- a/agent/csi/libstorage/csi_service_libstorage_idemp.go
+++ b/agent/csi/libstorage/csi_service_libstorage_idemp.go
@@ -143,7 +143,7 @@ func (d *driver) IsControllerPublished(
 		}
 	}
 
-	if _, ok := pvi.Values["token"]; !ok {
+	if _, ok := pvi.Values["token"]; ok {
 		// Token was not found via local devices
 		return nil, errLocDevsMissingVol
 	}


### PR DESCRIPTION
Fix #1122

I think the bug was introduced by this PR: https://github.com/thecodeteam/rexray/pull/1060/files
@codenrhoden do you remember why you check if the key exists in the map for sending an `errLocDevsMissingVol` error?