### PR TITLE
Add EBS_ENDPOINT to EBS Docker Managed plugin

### DIFF
--- a/.docker/plugins/ebs/config.json
+++ b/.docker/plugins/ebs/config.json
@@ -85,6 +85,14 @@
         },
         {
           "Description": "",
+          "Name": "EBS_ENDPOINT",
+          "Settable": [
+            "value"
+          ],
+          "Value": ""
+        },
+        {
+          "Description": "",
           "Name": "EBS_KMSKEYID",
           "Settable": [
             "value"


### PR DESCRIPTION
This patch adds `EBS_ENDPOINT` to the Docker managed plugin, which should allow a user to set the endpoint directly when using the plugin. This should solve #1118 .