### PR TITLE
Give EBS endpoint precedence over region

### DIFF
--- a/libstorage/drivers/storage/ebs/storage/ebs_storage.go
+++ b/libstorage/drivers/storage/ebs/storage/ebs_storage.go
@@ -136,11 +136,11 @@ func (d *driver) Login(ctx types.Context) (interface{}, error) {
 		region   = d.mustRegion(ctx)
 	)
 
-	if region != nil {
+	if d.endpoint != nil {
+		endpoint = d.endpoint
+	} else {
 		szEndpint := fmt.Sprintf("ec2.%s.amazonaws.com", *region)
 		endpoint = &szEndpint
-	} else {
-		endpoint = d.endpoint
 	}
 
 	writeHkey(hkey, region)


### PR DESCRIPTION
If a user has configured an endpoint to use for AWS, always use it,
rather than deferring to an auto-generated endpoint based on the region.