### PR TITLE
Close a tag in docs for DigitalOcean Docker plugin.

### DIFF
--- a/.docs/user-guide/schedulers/docker/plug-ins/digitalocean.md
+++ b/.docs/user-guide/schedulers/docker/plug-ins/digitalocean.md
@@ -5,9 +5,9 @@ Block Storage
 ---
 
 <a name="digitalocean-block-storage"></a>
-<a name="dobs"></a
+<a name="dobs"></a>
 
-## DO Block Storage>
+## DO Block Storage
 The DOBS plug-in can be installed with the following command:
 
 ```bash


### PR DESCRIPTION
Not just a tag, but an a tag even! :wink: 

Fixes display of https://rexray.readthedocs.io/en/stable/user-guide/schedulers/docker/plug-ins/digitalocean/