### PR TITLE
Skip unauthorized pools in the rbd driver.

### DIFF
--- a/libstorage/drivers/storage/rbd/storage/rbd_storage.go
+++ b/libstorage/drivers/storage/rbd/storage/rbd_storage.go
@@ -100,7 +100,7 @@ func (d *driver) Volumes(
 	for _, pool := range pools {
 		images, err := utils.GetRBDImages(ctx, pool)
 		if err != nil {
-			return nil, err
+			continue
 		}
 
 		vols, err := d.toTypeVolumes(


### PR DESCRIPTION
Try to use rexray in the non-privilege account.